### PR TITLE
chore: add logs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ ENV/
 htmlcov/
 .coverage.*
 
+# Logs
+logs/
+
 # Documentation
 site/
 


### PR DESCRIPTION
## Summary
- Add `logs/` directory to `.gitignore` to prevent log files from being tracked in version control

## Changes
- Added `logs/` entry under the "Logs" section in `.gitignore`

## Test plan
- [x] Verified logs directory is now ignored by git
- [x] Pre-commit hooks passed

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: sonnet-4.5
- **AI Contribution**: ~100% (estimated based on lines added/changed)
- **AI Reason**: gitignore update
- **Human Oversight**: Code reviewed and approved by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)