### PR TITLE
fix(tac-sync-issues): prepend test_automation_scripts_directory to file path for new issues

### DIFF
--- a/github_ops_manager/configuration/cli.py
+++ b/github_ops_manager/configuration/cli.py
@@ -116,9 +116,10 @@ def tac_sync_issues_cli(
                     f"path of '{test_case_definition.generated_script_path}' - "
                     "creating a Pull Request"
                 )
+                script_path = test_automation_scripts_directory / test_case_definition.generated_script_path
                 new_issue.pull_request = PullRequestModel(
                     title=f"GenAI, Review: {test_case_definition.title}",
-                    files=[test_case_definition.generated_script_path],
+                    files=[str(script_path)],
                 )
             desired_issues_yaml_model.issues.append(new_issue)
         else:


### PR DESCRIPTION
## Summary

- Fixes bug where new issues created by `tac-sync-issues` command had incomplete file paths in the pull request `files` list
- The `generated_script_path` was being used directly without prepending `test_automation_scripts_directory`
- This caused file paths like `iosxr/file.robot` instead of `workspace/jobfiles/iosxr/file.robot`

## Root Cause

When creating a **new issue** with a pull request, the code used `generated_script_path` directly:
```python
files=[test_case_definition.generated_script_path]
```

But when **updating an existing issue**, the code correctly prepended the base directory:
```python
script_path = test_automation_scripts_directory / test_case_definition.generated_script_path
files=[str(script_path)]
```

This inconsistency caused the `process-issues` command to look for files in the wrong location.

## Test plan

- [x] Validated fix in CXTA-DISA-DISN-NextGen-Testbed Jenkins pipeline
- [x] File paths now correctly include the `workspace/jobfiles/` prefix
- [x] Pull requests can be created successfully with the correct file attachments

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.5
- **AI Contribution**: ~100%
- **AI Reason**: bug fix implementation
- **Human Oversight**: Code reviewed and validated through Jenkins pipeline testing